### PR TITLE
Refactor: Steps Refactored to Prevent the unnecessary coverage while …

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Tools • Dart 2.12.0
 
 ## Initial setup
 
-### Change Flutter app package
-
-- Search and Replace All `nft` to new package name
-
 ### Change App display name
 
 - Search and Replace All `NFT App` to new App display name
@@ -22,6 +18,11 @@ Tools • Dart 2.12.0
 
 - Search and Replace All `com.nhancv.nft` to new App bundle id
 - Update directory folder path name of Android (`android/app/src/main/kotlin/`) same with new App bundle id
+
+### Change Flutter app package
+
+- Search and Replace All `nft` to new package name
+
 
 ## Update app icon
 


### PR DESCRIPTION
…replace

When "nft" is the first step it will find and replace "NFT App" as well. Which is not what we want. Later when we try to find "NFT App" it will not found. Also same will happen for bundle id